### PR TITLE
Update SPOT.py

### DIFF
--- a/SPOT/SPOT.py
+++ b/SPOT/SPOT.py
@@ -15,5 +15,5 @@ url = config.get('general', 'url')
 token_header = { 'token': config.get('general', 'token')}
 response = requests.get(url, headers=token_header)
 
-print("Content-type: application/json", end="\r\n\r\n", flush=True)
-print(json.dumps(response.json()))
+print("Access-Control-Allow-Origin: *", end="\r\n\r\n")
+print(json.dumps(response.json(), indent=4))


### PR DESCRIPTION
I removed the `print("Content-type: application/json", end="\r\n\r\n", flush=True)` because it was showing up outside json at the top of the page and interfering with the ability to parse it. I also added an `indent=4` for readability in browser without a JSON Viewer. 

Once I removed the content type line the JSON Viewer plugin recognized it and I was able to parse it as JSON in FEV.
